### PR TITLE
docs: add default role permissions table

### DIFF
--- a/docs/base/roles.md
+++ b/docs/base/roles.md
@@ -4,3 +4,14 @@
 - admin — администратор семьи, управляет участниками и настройками.
 - member — участник семьи, может взаимодействовать с контентом.
 - guest — гость с минимальным доступом.
+
+## Права по умолчанию
+
+Ниже приведена таблица с основными пермишенами и доступом к ним по умолчанию для каждой роли. В конкретной семье эти права могут быть настроены иначе.
+
+| Роль \\ Пермишен | family:read | family:update | member:invite:create | member:role:update | role:permissions:update | source:create | media:list | media:comment:create | media:comment:moderate | genealogy:person:delete | sync:trigger | security:audit:view |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| owner | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| admin | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| member | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ |
+| guest | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |


### PR DESCRIPTION
## Summary
- add default permission matrix for roles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b7d4a5288325b3424294c277cd67